### PR TITLE
#2 fix: make program able to handle an odd number of cadets

### DIFF
--- a/async-pairamizer.js
+++ b/async-pairamizer.js
@@ -7,10 +7,15 @@ function makePairs() {
 
     console.log('this is cadetList', cadetList);
 
+
     //read cadet-list file of made pairs and create array where each element is a pair of previous names
     const madePairs = fs.readFileSync('pairs-list.txt', 'utf8').split('\n').filter(pair => pair !== '');
 
     console.log('this is pairs-list BEFORE', madePairs);
+
+    if (cadetList.length % 2 !== 0) {
+        cadetList.push('ODD ONE OUT')
+    }
 
     //create brand new pairs
     const newPairs = createPairs(cadetList, madePairs);


### PR DESCRIPTION
closes #2 
# In this PR you will find:
- A check that adds a 'ODD ONE OUT' string to be paired with a cadet name, making the list even.
- This will be append to `pair-list.js` file and will allow us to check who was the last cadet to be left out.